### PR TITLE
[회원] 회원 엔티티 생성

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: 기능 구현시 issue
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## 어떤 기능인가요?
+
+> 추가하려는 기능에 대해 간결하게 설명해주세요
+
+## 작업 상세 내용
+
+- [ ] TODO
+- [ ] TODO
+- [ ] TODO

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-application.yml
+# application.yml
+.env
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // env file
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 
     // env file
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
+    // for swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springdoc:springdoc-openapi-starter-common:2.3.0")
 }
 
 tasks.named('test') {

--- a/src/main/java/itcen/whiteboardserver/config/OpenAPIConfig.java
+++ b/src/main/java/itcen/whiteboardserver/config/OpenAPIConfig.java
@@ -1,0 +1,34 @@
+package itcen.whiteboardserver.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "DRAWCEN API 명세서",
+                description = "DRAWCEN 프로젝트 API 명세서",
+                version = "v1"
+        )
+//        security = {@SecurityRequirement(name = "Bearer Authentication")}
+)
+@Configuration
+public class OpenAPIConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+            return new OpenAPI();
+    }
+
+    @Bean
+    public GroupedOpenApi userApi() {
+        return GroupedOpenApi.builder()
+                .group("멤버 관련 API")
+                .pathsToMatch("/api/member/**") // 특정 경로만 포함
+                .build();
+    }
+
+}

--- a/src/main/java/itcen/whiteboardserver/member/application/controller/MemberController.java
+++ b/src/main/java/itcen/whiteboardserver/member/application/controller/MemberController.java
@@ -29,18 +29,13 @@ public class MemberController {
             summary = "멤버 조회",
             description =
                     """
-                    멤버 id를 기반으로 멤버 정보를 조회해옵니다.
+                    멤버 id를 기반으로 멤버 정보를 조회해옵니다.\n
                     후에는 JWT 토큰을 통해 멤버 정보를 조회할 것입니다.
                     """
     )
-    public ResponseEntity<Map<String, Object>> getMember(@PathVariable("id") Long id) {
+    public ResponseEntity<MemberDTO> getMember(@PathVariable("id") Long id) {
         MemberDTO member = memberService.getMemberById(id);
         return ResponseEntity.ok()
-                .body(Map.of(
-                        "msg", "성공",
-                        "result", member,
-                        "status", HttpStatus.OK
-                ));
-
+                .body(member);
     }
 }

--- a/src/main/java/itcen/whiteboardserver/member/application/controller/MemberController.java
+++ b/src/main/java/itcen/whiteboardserver/member/application/controller/MemberController.java
@@ -1,0 +1,38 @@
+package itcen.whiteboardserver.member.application.controller;
+
+import itcen.whiteboardserver.member.application.dto.MemberDTO;
+import itcen.whiteboardserver.member.application.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> getMember(@PathVariable("id") Long id) {
+        // Logic to retrieve member by ID
+        MemberDTO member = memberService.getMemberById(id);
+        return ResponseEntity.ok()
+                .body(Map.of(
+                        "msg", "성공",
+                        "result", member,
+                        "status", HttpStatus.OK
+                ));
+
+    }
+}

--- a/src/main/java/itcen/whiteboardserver/member/application/controller/MemberController.java
+++ b/src/main/java/itcen/whiteboardserver/member/application/controller/MemberController.java
@@ -1,5 +1,6 @@
 package itcen.whiteboardserver.member.application.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import itcen.whiteboardserver.member.application.dto.MemberDTO;
 import itcen.whiteboardserver.member.application.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,8 +25,15 @@ public class MemberController {
     }
 
     @GetMapping("/{id}")
+    @Operation(
+            summary = "멤버 조회",
+            description =
+                    """
+                    멤버 id를 기반으로 멤버 정보를 조회해옵니다.
+                    후에는 JWT 토큰을 통해 멤버 정보를 조회할 것입니다.
+                    """
+    )
     public ResponseEntity<Map<String, Object>> getMember(@PathVariable("id") Long id) {
-        // Logic to retrieve member by ID
         MemberDTO member = memberService.getMemberById(id);
         return ResponseEntity.ok()
                 .body(Map.of(

--- a/src/main/java/itcen/whiteboardserver/member/application/dto/MemberDTO.java
+++ b/src/main/java/itcen/whiteboardserver/member/application/dto/MemberDTO.java
@@ -1,5 +1,6 @@
 package itcen.whiteboardserver.member.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
@@ -7,7 +8,10 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberDTO {
+    @Schema(description = "회원 ID", example = "1")
     private Long id;
+    @Schema(description = "회원 이름", example = "aa")
     private String name;
+    @Schema(description = "회원 email", example = "aa@gmail.com")
     private String email;
 }

--- a/src/main/java/itcen/whiteboardserver/member/application/dto/MemberDTO.java
+++ b/src/main/java/itcen/whiteboardserver/member/application/dto/MemberDTO.java
@@ -1,0 +1,13 @@
+package itcen.whiteboardserver.member.application.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberDTO {
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/itcen/whiteboardserver/member/application/service/MemberService.java
+++ b/src/main/java/itcen/whiteboardserver/member/application/service/MemberService.java
@@ -1,0 +1,10 @@
+package itcen.whiteboardserver.member.application.service;
+
+import itcen.whiteboardserver.member.application.dto.MemberDTO;
+
+public interface MemberService {
+    // Define the methods that will be implemented in the service class
+    MemberDTO getMemberById(Long id);
+
+    // Add other member-related methods as needed
+}

--- a/src/main/java/itcen/whiteboardserver/member/domain/aggregate/entity/Member.java
+++ b/src/main/java/itcen/whiteboardserver/member/domain/aggregate/entity/Member.java
@@ -1,0 +1,31 @@
+package itcen.whiteboardserver.member.domain.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Entity
+@Table(name = "member")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email", unique = true, nullable = false)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+}

--- a/src/main/java/itcen/whiteboardserver/member/domain/repository/MemberRepository.java
+++ b/src/main/java/itcen/whiteboardserver/member/domain/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package itcen.whiteboardserver.member.domain.repository;
+
+import itcen.whiteboardserver.member.domain.aggregate.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/itcen/whiteboardserver/member/domain/service/MemberServiceImpl.java
+++ b/src/main/java/itcen/whiteboardserver/member/domain/service/MemberServiceImpl.java
@@ -1,0 +1,26 @@
+package itcen.whiteboardserver.member.domain.service;
+
+import itcen.whiteboardserver.member.application.dto.MemberDTO;
+import itcen.whiteboardserver.member.application.service.MemberService;
+import itcen.whiteboardserver.member.domain.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public MemberServiceImpl(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public MemberDTO getMemberById(Long id) {
+
+        return memberRepository.findById(id)
+                .map(member -> new MemberDTO(member.getId(), member.getName(), member.getEmail()))
+                .orElse(null);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,10 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: drawcen
+  datasource:
+    url: jdbc:postgresql://${DATABASE_HOST}:${POSTGRESQL_DATABASE_PORT}/${POSTGRESQL_DATABASE_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    show-sql: true
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
## 📌 Related Issue
(#2)
## 🚀 Description
회원 엔티티 생성했습니다.
추가적으로 swagger, dotenv, postgres 연결 설정을 했습니다.
## 📸 Screenshot
1. swagger 사용방법
1.1 summary
- summary 작성 방법
![image](https://github.com/user-attachments/assets/07994d78-763f-4cf2-a8a7-9b396f872e62)
- 결과
![image](https://github.com/user-attachments/assets/2e518e47-4b02-4875-af6a-42c9a2790721)

1.2 response 관련
- responseDTO에 @schema 추가
![image](https://github.com/user-attachments/assets/8309b06b-5211-4dc5-806d-bca9d443ba12)
- 결과
![image](https://github.com/user-attachments/assets/c14875ac-0fdd-446b-bbac-6fb51e637e27)

2. dotenv 설정
yml에 있는 민감한 정보들을 dotenv에 관리할 수 있도록 했습니다.
![image](https://github.com/user-attachments/assets/a532fd9e-c862-46e9-8c02-2eaf8e643bef)


3. member 엔티티 생성 및 id로 가져올 수 있도록 endpoint 생성
![image](https://github.com/user-attachments/assets/85a4aab3-7925-422d-9bae-a7b5c089e6af)


## 📢 Notes
