### PR TITLE
[게임] 동시성 문제 일차적으로 해결 

### DIFF
--- a/src/main/java/com/itcen/whiteboardserver/turn/service/TurnServiceImpl.java
+++ b/src/main/java/com/itcen/whiteboardserver/turn/service/TurnServiceImpl.java
@@ -45,6 +45,7 @@ public class TurnServiceImpl implements TurnService {
     final int TURN_SECONDS = 150;
     final PlatformTransactionManager transactionManager;
     final ApplicationContext applicationContext;
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     @Override
     public void startTurn(Long gameId) {
@@ -72,7 +73,6 @@ public class TurnServiceImpl implements TurnService {
     }
 
     private void scheduleTurnOver(Long turnId) {
-        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         scheduler.schedule(() -> {
             TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
             txTemplate.execute(status -> {

--- a/src/main/java/com/itcen/whiteboardserver/turn/service/TurnServiceImpl.java
+++ b/src/main/java/com/itcen/whiteboardserver/turn/service/TurnServiceImpl.java
@@ -42,10 +42,10 @@ public class TurnServiceImpl implements TurnService {
     final TurnRepository turnRepository;
     final CorrectRepository correctRepository;
     final GameParticipationRepository gameParticipationRepository;
-    final int TURN_SECONDS = 150;
+    final int TURN_SECONDS = 10;
     final PlatformTransactionManager transactionManager;
     final ApplicationContext applicationContext;
-    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(5);
 
     @Override
     public void startTurn(Long gameId) {

--- a/src/main/java/com/itcen/whiteboardserver/turn/service/TurnServiceImpl.java
+++ b/src/main/java/com/itcen/whiteboardserver/turn/service/TurnServiceImpl.java
@@ -118,7 +118,6 @@ public class TurnServiceImpl implements TurnService {
         );
     }
 
-    @Transactional
     private void quitGame(Long gameId) {
         broadcastTurnScore(gameId, TurnResponseType.GAME_FINISH);
 
@@ -170,8 +169,7 @@ public class TurnServiceImpl implements TurnService {
         return true;
     }
 
-    @Transactional
-    private void doTurnOver(Long gameId) {
+    private synchronized void doTurnOver(Long gameId) {
         Game game = getGameByGameId(gameId);
         Turn turn = game.getCurrentTurn();
 
@@ -189,7 +187,6 @@ public class TurnServiceImpl implements TurnService {
         applicationContext.getBean(TurnService.class).startTurn(gameId);
     }
 
-    @Transactional
     private void finalizeTurnScore(Long gameId) {
         Game game = getGameByGameId(gameId);
         Turn turn = game.getCurrentTurn();
@@ -224,7 +221,6 @@ public class TurnServiceImpl implements TurnService {
         broadcastTurnScore(gameId, TurnResponseType.FINISH);
     }
 
-    @Transactional
     private void broadcastTurnScore(Long gameId, TurnResponseType type) {
         Game game = getGameByGameId(gameId);
 


### PR DESCRIPTION
## 📌 Related Issue
#31 #20 

## 🚀 Description
### 현재 문제 시나리오 
```
1. a의 턴 시작
2. 2분 29초 후반 쯤에 b가 정답 요청
3. 2분 30초 타이머 돌아감

b의 정답 요청과 2분 30초 타이머가 동시에 돌아가서 검증도 우연하게 통과하는 경우에 턴이 두 번 발행됨, 또한 로직이 꼬임
```
일차적으로 synchronized 키워드로 막았지만, 성능이 너무 떨어지고 구조적으로 리팩토링이 필요하다고 판단됨.
이후 로직 리팩토링을 통해 동시성을 보장할 예정. (DB Locking 사용)

## 📸 Screenshot

## 📢 Notes
