### PR TITLE
[게임] 게임 동시성 제어 로직 

### DIFF
--- a/src/main/java/com/itcen/whiteboardserver/game/entity/Game.java
+++ b/src/main/java/com/itcen/whiteboardserver/game/entity/Game.java
@@ -24,6 +24,15 @@ public class Game {
     @Column(nullable = false)
     private GameStatus status;
 
+    @Version
+    private int version;
+
+    public Game(Long id, Turn currentTurn, GameStatus status) {
+        this.id = id;
+        this.currentTurn = currentTurn;
+        this.status = status;
+    }
+
     public enum GameStatus {
         NOT_STARTED, IN_PROGRESS, ENDED
     }
@@ -36,7 +45,7 @@ public class Game {
         currentTurn = null;
     }
 
-    public void quitGame(){
+    public void quitGame() {
         status = GameStatus.ENDED;
     }
 }

--- a/src/main/java/com/itcen/whiteboardserver/game/repository/RoomRepository.java
+++ b/src/main/java/com/itcen/whiteboardserver/game/repository/RoomRepository.java
@@ -1,9 +1,13 @@
 package com.itcen.whiteboardserver.game.repository;
 
+import com.itcen.whiteboardserver.game.entity.Game;
 import com.itcen.whiteboardserver.game.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    Optional<Room> findByCurrentGame(Game game);
 }

--- a/src/main/java/com/itcen/whiteboardserver/game/session/GameSession.java
+++ b/src/main/java/com/itcen/whiteboardserver/game/session/GameSession.java
@@ -6,13 +6,15 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Component
 public class GameSession {
     private final Map<Long, GameState> gameSession = new ConcurrentHashMap<>();
+    private final Map<Long, ReentrantLock> locks = new ConcurrentHashMap<>();
 
-    //TODO: Exception 반환형 추후 고려
-    public synchronized void createSession(Long gameId, GameState gameState) {
+    public void createSession(Long gameId, GameState gameState) {
         if (gameSession.containsKey(gameId)) {
             throw new RuntimeException("Already this game session created");
         }
@@ -20,57 +22,63 @@ public class GameSession {
         gameSession.put(gameId, gameState);
     }
 
-    public synchronized void removeSession(Long gameId) {
+    public void removeSession(Long gameId) {
         validateGameExist(gameId);
 
         gameSession.remove(gameId);
+        locks.remove(gameId);
     }
 
-    public synchronized String thisTurnQuizWord(Long gameId) {
-        GameState gameState = getGameState(gameId);
-
-        return gameState.getQuizWords().get(gameState.getNowTurn());
-    }
-
-    public synchronized boolean canGoNextTurn(Long gameId) {
+    public boolean canGoNextTurn(Long gameId) {
         GameState gameState = getGameState(gameId);
         return !(gameState.getNowTurn() + 1 >= gameState.getTotalTurnCnt());
     }
 
-    public synchronized Long goNextTurnAndGetDrawer(Long gameId) {
-        GameState gameState = getGameState(gameId);
-        gameState.goNextTurn();
+    public Long goNextTurnAndGetDrawer(Long gameId) {
+        Lock lock = getLock(gameId);
+        lock.lock();
 
-        int drawerId = gameState.getNowTurn() % gameState.getDrawerSequence().size();
-        return gameState.getDrawerSequence().get(drawerId);
+        try {
+            GameState gameState = getGameState(gameId);
+            gameState.goNextTurn();
+
+            int drawerId = gameState.getNowTurn() % gameState.getDrawerSequence().size();
+            return gameState.getDrawerSequence().get(drawerId);
+        } finally {
+            lock.unlock();
+        }
     }
 
-    public synchronized String getNowTurnQuizWord(Long gameId) {
+    public String getNowTurnQuizWord(Long gameId) {
         GameState gameState = getGameState(gameId);
 
         return gameState.getThisTurnWord();
     }
 
-    public synchronized boolean isGamePlaying(Long gameId) {
+    public boolean isGamePlaying(Long gameId) {
         GameState gameState = getGameState(gameId);
         GameStatus status = gameState.getStatus();
 
         return status == GameStatus.IN_TURN;
     }
 
-    public synchronized boolean isThisMemberParticipant(Long gameId, Long memberId) {
+    public boolean isThisMemberParticipant(Long gameId, Long memberId) {
         GameState gameState = getGameState(gameId);
 
         return gameState.getDrawerSequence().contains(memberId);
     }
 
-    public synchronized boolean isThisDrawer(Long gameId, Long memberId) {
+    public boolean isThisDrawer(Long gameId, Long memberId) {
         GameState gameState = getGameState(gameId);
 
         int drawerIdx = gameState.getNowTurn() % gameState.getDrawerSequence().size();
         Long drawerId = gameState.getDrawerSequence().get(drawerIdx);
 
         return memberId == drawerId;
+    }
+
+    private Lock getLock(Long gameId) {
+        return locks.computeIfAbsent(gameId, id -> new ReentrantLock());
     }
 
     private GameState getGameState(Long gameId) {

--- a/src/main/java/com/itcen/whiteboardserver/game/session/state/GameState.java
+++ b/src/main/java/com/itcen/whiteboardserver/game/session/state/GameState.java
@@ -20,7 +20,6 @@ public class GameState {
     private GameStatus status;
 
 
-    //TODO: Exception 반환형 추후 고려
     public static GameState createGameState(List<Long> drawerSequence, List<String> quizWords) {
         int drawerCnt = drawerSequence.size();
         if (drawerCnt < 2 || drawerCnt > 6) {


### PR DESCRIPTION
## 📌 Related Issue
#44  

## 🚀 Description
기존 문제점 
1. GameSession에서의 무지성 `synchronized`
2. TurnService에서의 `synchronized` 남발;

두 가지를 수정해보았습니다.
1. 코드 단에서 Lock을 걸어 게임 단으로 접근하도록 변경
2. DB 단에서 낙관적 락을 통해 version 변경 시에, 낙관적 락 Exception 반환

```java
@Entity
@Table(name = "game")
@Getter
@NoArgsConstructor
@AllArgsConstructor
public class Game {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id; // 게임 ID

    @OneToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "current_turn_id")
    private Turn currentTurn; // 현재 턴

    @Enumerated(EnumType.STRING)
    @Column(nullable = false)
    private GameStatus status;

    @Version
    private int version;
}
```
위와 같이 version 칼럼이 추가되었기 때문에 이에 대한 DB 처리 해주셔야됩니다.. 밀고 다시 해주시면 감사하겠습니다. 
혹은,
```sql
ALTER TABLE game ADD COLUMN version INTEGER DEFAULT 0;
```
쿼리 날려서도 가능합니다!

+)추가적으로 하다가,
게임 끝난 다음에 방 WAITING 상태로 변경하지 않는 거 확인해서 이번 브랜치에서 겸사겸사 고쳤습니다. 

## 📸 Screenshot

## 📢 Notes
Exception 공통된 형식으로 변경하기 추후 예정!!! 
